### PR TITLE
Bump RL8 default ceph version to quincy

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -17,7 +17,7 @@ os_manila_mount_share_info: [] # populated by lookup mode
 os_manila_mount_ceph_min_versions: # default to oldest-available in for distro version:
 # see os_manila_mount_ceph_release_repos below for URLs to check
   Rocky:
-    "8": '15.2.17' # octopus
+    "8": '17.2.7' # quincy
     "9": '17.2.7' # quincy
   Ubuntu:
     "22": '17.2.7' # jammy: quincy


### PR DESCRIPTION
Octopus repos are no longer available.