### PR TITLE
Add CI to publish role

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+* @stackhpc/ansible

--- a/.github/workflows/publish-role.yml
+++ b/.github/workflows/publish-role.yml
@@ -1,0 +1,12 @@
+---
+name: Publish Ansible Role
+'on':
+  push:
+    tags:
+      - "v?[0-9]+.[0-9]+.[0-9]+"
+  workflow_dispatch:
+jobs:
+  publish_role:
+    uses: stackhpc/.github/.github/workflows/publish-role.yml@main
+    secrets:
+      GALAXY_API_KEY: ${{ secrets.GALAXY_API_KEY }}


### PR DESCRIPTION
The ansible-role-os-manila-mount is at v25.1.1 in this repo.

It exists twice in ansible-galaxy.
[stackhpc.os-manila-mount](https://galaxy.ansible.com/ui/standalone/roles/stackhpc/os-manila-mount/) v20.7.0 - 5 years old
[stackhpc.os_manila_mount](https://galaxy.ansible.com/ui/standalone/roles/stackhpc/os_manila_mount/) v24.1.0 - 1 year old

The readme points to use ansible-galaxy and the 5 year old release.

This looks to be consistent with how other roles are handled.