### PR TITLE
Refactor install.yml for Ubuntu Noble

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Mount one or more shares created by OpenStack Manila.
 Currently only supports:
 - CephFS-protocol shares
 - RockyLinux 8 and 9
-- Ubuntu Jammy
+- Ubuntu Jammy and Noble
 
 Requirements
 ------------
@@ -71,9 +71,9 @@ that, this should be a list of dicts each containing:
 `-v` will expose `access_key`.
 
 Ceph variables:
-* `os_manila_mount_ceph_version`: Optional. Ceph numerical version string, e.g. '17.2.7' not 'quincy'. Default is the oldest supported by the hosts' distribution/version. Must be 15.2.x (Octopus) or later. Note that on RockyLinux changing this and rerunning the role can change the installed version, but on Ubuntu it cannot.
-* `os_manila_mount_ceph_repo_key`: Optional. URL for Ceph repo key.
-* `os_manila_mount_ceph_release_repo`: Optional. URL for Ceph release repo.
+* `os_manila_mount_ceph_version`: Optional. Ceph numerical version string, e.g. '17.2.7' not 'quincy'. Default is the oldest supported by the hosts' distribution/version. Must be 15.2.x (Octopus) or later. Note that on RockyLinux changing this and rerunning the role can change the installed version, but on Ubuntu it cannot. After Ubuntu Jammy, this variable has no effect and the version of `ceph-common` available in the distribution repository is installed.
+* `os_manila_mount_ceph_repo_key`: Optional. URL for Ceph repo key. No effect after Ubuntu Jammy.
+* `os_manila_mount_ceph_release_repo`: Optional. URL for Ceph release repo. No effect after Ubuntu Jammy.
 * `os_manila_mount_ceph_conf_path`: Optional. Path for Ceph configuration directory,
 default `/etc/ceph`.
 

--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -34,13 +34,16 @@
   when: ansible_distribution == 'Rocky'
 
 - block:
-    - name: Install Ceph apt key
-      ansible.builtin.apt_key:
-        url: "{{ os_manila_mount_ceph_repo_key }}"
+    - block:
+        - name: Install Ceph apt key
+          ansible.builtin.apt_key:
+            url: "{{ os_manila_mount_ceph_repo_key }}"
 
-    - name: Install Ceph release repo (apt)
-      ansible.builtin.apt_repository:
-        repo: "deb {{ os_manila_mount_ceph_release_repo }} {{ ansible_distribution_release }} main"
+        - name: Install Ceph release repo (apt)
+          ansible.builtin.apt_repository:
+            repo: "deb {{ os_manila_mount_ceph_release_repo }} {{ ansible_distribution_release }} main"
+
+      when: ansible_distribution_major_version == "22"
 
     - name: Install Ceph packages (apt)
       ansible.builtin.apt:


### PR DESCRIPTION
After Ubuntu Jammy, packages are no longer distributed from the Ceph mirrors, but are available from the distro repositories directly. Skip configuring Ceph repositories after Ubuntu Jammy and use the packages from the distro repos.